### PR TITLE
让px转换支持浮点数

### DIFF
--- a/lib/pxrem-provider.js
+++ b/lib/pxrem-provider.js
@@ -1,6 +1,6 @@
 'use babel'
 
-const pxReg = /^\d+(p|px)$/
+const pxReg = /^[+-]?([0-9]*[.])?[0-9]+(p|px)$/
 
 export default {
     selector: '.source.css, .source.less, .source.scss, .source.sass, .source.styl',


### PR DESCRIPTION
虽然感觉 px 很少有小数，但是支持的更广泛一些看起来并没什么坏处。