### PR TITLE
修复自动完成对浮点数的支持

### DIFF
--- a/lib/pxrem-provider.js
+++ b/lib/pxrem-provider.js
@@ -1,15 +1,16 @@
 'use babel'
 
-const pxReg = /^[+-]?([0-9]*[.])?[0-9]+(p|px)$/
+const pxReg = /[+-]?([0-9]*[.])?[0-9]+(p|px)$/
 
 export default {
     selector: '.source.css, .source.less, .source.scss, .source.sass, .source.styl',
     disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string, .source.less .comment, .source.less .string, .source.styl .comment, .source.styl .string, .source.scss .comment, .source.scss .string',
-    getSuggestions({editor, bufferPosition, prefix}) {
-        const lineNum = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    getSuggestions({editor, bufferPosition}) {
+        const lineText = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+        const matches = pxReg.exec(lineText)
 
-        if(pxReg.test(prefix)){
-            let num = parseFloat(prefix)
+        if(matches){
+            let num = parseFloat(matches[0])
             if(num <= 1) return
             num = Number((num / atom.config.get('pxrem.base')).toFixed(atom.config.get('pxrem.length')))
             return [{


### PR DESCRIPTION
上一个PR出问题的原因是，autocomplete manager 的 prefix 正则表达式会排除掉“.“这个符号，所以导致 getSuggestions() 的 prefix 参数获取不到带“.“的内容。

基于目前的代码，我想去改动 autocomplete 是不现实的，所以改用获取当前行内容的方式解决。（亲测有效）